### PR TITLE
Increase timeout for Firebase function to run tests

### DIFF
--- a/functions/src/handlers/startPromptTests.ts
+++ b/functions/src/handlers/startPromptTests.ts
@@ -27,75 +27,81 @@ export const startPromptTestsHandler = (
   promptService: PromptDatabaseService,
   testResultsService: TestResultsDatabaseService
 ) =>
-  onRequest({cors: true}, async (req, res) => {
-    const data = req.body;
-    const promptId = data.promptId;
-    if (!promptId) {
-      res.status(400).send("No promptId parameter provided");
-      return;
-    }
-
-    const prompt: PromptCandidate | null = await promptService.get(promptId);
-    if (!prompt) {
-      res.status(400).send(`Prompt with id ${promptId} not found`);
-      return;
-    }
-
-    const testCases: TestCase[] = await testCaseService.getAll();
-
-    const promptTestResults =
-      await testResultsService.initializePromptTestResultsRecord(
-        testCases,
-        promptId,
-        OPENAI_MODEL,
-        EMBEDDING_MODEL_NAME,
-        TEMPERATURE,
-        MAX_TOKENS
-      );
-
-    if (!promptTestResults.id) {
-      res.status(500).send("Error initializing prompt test results record");
-      return;
-    }
-
-    try {
-      testCases.forEach((testCase: TestCase) => {
-        // Do not `await` here so that the tests can all start and we can
-        //  return a response while they run.
-        processTestCase(
-          prompt,
-          testCase,
-          promptTestResults,
-          testResultsService
-        ).catch((error) => {
-          logger.error(`Error running test case ${testCase.id}: ${error}`);
-        });
-      });
-    } catch (error) {
-      logger.error(`Error starting tests for prompt ${promptId}: ${error}`);
-
-      // delete the prompt test results record if there was an error
-      // try setting its status to ERROR if that deletion failed
-      try {
-        await testResultsService.deletePromptTestResultsRecord(
-          promptTestResults.id
-        );
-      } catch (error) {
-        logger.error(
-          `Error deleting prompt test results
-            record ${promptTestResults.id}: ${error}`
-        );
-        await testResultsService.updatePromptTestResultsStatus(
-          promptTestResults.id,
-          TestResultsStatus.ERROR
-        );
+  onRequest(
+    {
+      cors: true,
+      timeoutSeconds: 1800, // 30 minutes (max is 1 hour)
+    },
+    async (req, res) => {
+      const data = req.body;
+      const promptId = data.promptId;
+      if (!promptId) {
+        res.status(400).send("No promptId parameter provided");
+        return;
       }
 
-      res
-        .status(500)
-        .send(`Error starting tests for prompt ${promptId}: ${error}`);
-      return;
-    }
+      const prompt: PromptCandidate | null = await promptService.get(promptId);
+      if (!prompt) {
+        res.status(400).send(`Prompt with id ${promptId} not found`);
+        return;
+      }
 
-    res.send({message: `Started tests for prompt ${promptId}`});
-  });
+      const testCases: TestCase[] = await testCaseService.getAll();
+
+      const promptTestResults =
+        await testResultsService.initializePromptTestResultsRecord(
+          testCases,
+          promptId,
+          OPENAI_MODEL,
+          EMBEDDING_MODEL_NAME,
+          TEMPERATURE,
+          MAX_TOKENS
+        );
+
+      if (!promptTestResults.id) {
+        res.status(500).send("Error initializing prompt test results record");
+        return;
+      }
+
+      try {
+        testCases.forEach((testCase: TestCase) => {
+          // Do not `await` here so that the tests can all start and we can
+          //  return a response while they run.
+          processTestCase(
+            prompt,
+            testCase,
+            promptTestResults,
+            testResultsService
+          ).catch((error) => {
+            logger.error(`Error running test case ${testCase.id}: ${error}`);
+          });
+        });
+      } catch (error) {
+        logger.error(`Error starting tests for prompt ${promptId}: ${error}`);
+
+        // delete the prompt test results record if there was an error
+        // try setting its status to ERROR if that deletion failed
+        try {
+          await testResultsService.deletePromptTestResultsRecord(
+            promptTestResults.id
+          );
+        } catch (error) {
+          logger.error(
+            `Error deleting prompt test results
+            record ${promptTestResults.id}: ${error}`
+          );
+          await testResultsService.updatePromptTestResultsStatus(
+            promptTestResults.id,
+            TestResultsStatus.ERROR
+          );
+        }
+
+        res
+          .status(500)
+          .send(`Error starting tests for prompt ${promptId}: ${error}`);
+        return;
+      }
+
+      res.send({message: `Started tests for prompt ${promptId}`});
+    }
+  );


### PR DESCRIPTION
I deployed these changes to the production Firebase functions around 9:20 AM on 4/29.

See [this](https://firebase.google.com/docs/functions/manage-functions?gen=2nd#set_timeout_and_memory_allocation) Firebase documentation and also [this ](https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.https.httpsoptions.md#httpshttpsoptionstimeoutseconds) which specifies the 1-hour max for onRequest HTTP functions.

The other changes besides the addition on (new) line 33 are auto-formatting changes due to indenting and such.